### PR TITLE
Bitmap allocator

### DIFF
--- a/include/felspar/memory/bitmap.strategy.hpp
+++ b/include/felspar/memory/bitmap.strategy.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+
+#include <utility>
+
+
+namespace felspar::memory::bitmap {
+
+
+    /**
+     * The bitmap allocator uses a bitmap to store which blocks are free and
+     * which are currently in use. A set bit indicates a used location and a
+     * zero bit indicates allocated. All memory requests must be for less than
+     * the block size.
+     */
+
+
+    /// The number of bits available in the type
+    template<typename BM>
+    constexpr std::size_t bitcount = sizeof(BM) * 8;
+
+
+    /// Return the memory location that is allocated
+    template<typename BM>
+    constexpr inline std::size_t nextbit(BM allocations) {
+        std::size_t bit{};
+        for (BM mask{1}; bit < bitcount<BM> and allocations & mask;
+             ++bit, mask = (mask << 1u)) {}
+        return bit;
+    }
+
+
+    template<typename BM>
+    std::byte *allocate(BM &bm, std::byte *base, std::size_t blocksize) {
+        if (auto bit = nextbit(bm); bit < bitcount<BM>) {
+            bm |= 1 << bit;
+            return base + blocksize * bit;
+        } else {
+            return nullptr;
+        }
+    }
+
+
+    template<typename BM>
+    inline void free() {}
+
+
+}

--- a/include/felspar/memory/bitmap.strategy.hpp
+++ b/include/felspar/memory/bitmap.strategy.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 
-#include <utility>
+#include <cstddef>
 
 
 namespace felspar::memory::bitmap {

--- a/include/felspar/memory/bitmap.strategy.hpp
+++ b/include/felspar/memory/bitmap.strategy.hpp
@@ -42,7 +42,11 @@ namespace felspar::memory::bitmap {
 
 
     template<typename BM>
-    inline void free() {}
+    inline void free(
+            std::byte *ptr, BM &bm, std::byte *base, std::size_t blocksize) {
+        std::size_t const bit = (ptr - base) / blocksize;
+        bm &= ~(1 << bit);
+    }
 
 
 }

--- a/include/felspar/memory/bitmap.strategy.hpp
+++ b/include/felspar/memory/bitmap.strategy.hpp
@@ -42,7 +42,7 @@ namespace felspar::memory::bitmap {
 
 
     template<typename BM>
-    inline void free(
+    inline void deallocate(
             std::byte *ptr, BM &bm, std::byte *base, std::size_t blocksize) {
         std::size_t const bit = (ptr - base) / blocksize;
         bm &= ~(1 << bit);

--- a/include/felspar/memory/holding_pen.hpp
+++ b/include/felspar/memory/holding_pen.hpp
@@ -27,6 +27,9 @@ namespace felspar::memory {
         T &value() { return *store.data(); }
         T const &value() const { return *store.data(); }
 
+        bool has_value() const noexcept { return holding; }
+        explicit operator bool() const noexcept { return holding; }
+
         /// Get pen value or default
         template<typename U>
         T value_or(U &&default_value) const {
@@ -37,7 +40,6 @@ namespace felspar::memory {
             }
         }
 
-        explicit operator bool() const noexcept { return holding; }
         T *operator->() { return &value(); }
         T const *operator->() const { return &value(); }
         T &operator*() { return value(); }

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(memory-headers-tests STATIC EXCLUDE_FROM_ALL
         any_buffer.cpp
         atomic_pen.cpp
+        bitmap.strategy.cpp
         concepts.cpp
         control.cpp
         holding_pen.cpp

--- a/test/headers/bitmap.strategy.cpp
+++ b/test/headers/bitmap.strategy.cpp
@@ -1,0 +1,1 @@
+#include <felspar/memory/bitmap.strategy.hpp>

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(TARGET check)
     add_test_run(check felspar-memory TESTS
+            bitmap.cpp
             holding_pen.cpp
             raw_memory.cpp
             sizes.cpp

--- a/test/run/bitmap.cpp
+++ b/test/run/bitmap.cpp
@@ -1,0 +1,25 @@
+#include <felspar/memory/bitmap.strategy.hpp>
+#include <felspar/test.hpp>
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("bitmap allocator");
+
+
+    auto const nb = suite.test("nextbit", [](auto check) {
+        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b0000'0000}))
+                == 0u;
+        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b0000'0111}))
+                == 3u;
+        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b1111'1110}))
+                == 0u;
+        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b1111'0111}))
+                == 3u;
+        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b1111'1111}))
+                == 8u;
+    });
+
+
+}

--- a/test/run/bitmap.cpp
+++ b/test/run/bitmap.cpp
@@ -30,10 +30,10 @@ namespace {
         check(bm::allocate(blocks, memory.data(), 1u)) == memory.data() + 1;
         check(blocks) == 3u;
 
-        bm::free(memory.data(), blocks, memory.data(), 1u);
+        bm::deallocate(memory.data(), blocks, memory.data(), 1u);
         check(blocks) == 2u;
 
-        bm::free(memory.data() + 1, blocks, memory.data(), 1u);
+        bm::deallocate(memory.data() + 1, blocks, memory.data(), 1u);
         check(blocks) == 0u;
     });
 

--- a/test/run/bitmap.cpp
+++ b/test/run/bitmap.cpp
@@ -9,16 +9,32 @@ namespace {
 
 
     auto const nb = suite.test("nextbit", [](auto check) {
-        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b0000'0000}))
-                == 0u;
-        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b0000'0111}))
-                == 3u;
-        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b1111'1110}))
-                == 0u;
-        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b1111'0111}))
-                == 3u;
-        check(felspar::memory::bitmap::nextbit(std::uint8_t{0b1111'1111}))
-                == 8u;
+        namespace bm = felspar::memory::bitmap;
+        check(bm::nextbit(std::uint8_t{0b0000'0000})) == 0u;
+        check(bm::nextbit(std::uint8_t{0b0000'0111})) == 3u;
+        check(bm::nextbit(std::uint8_t{0b1111'1110})) == 0u;
+        check(bm::nextbit(std::uint8_t{0b1111'0111})) == 3u;
+        check(bm::nextbit(std::uint8_t{0b1111'1111})) == 8u;
+    });
+
+
+    auto const al = suite.test("allocate", [](auto check) {
+        std::array<std::byte, 32> memory{};
+        std::uint32_t blocks{};
+
+        namespace bm = felspar::memory::bitmap;
+
+        check(bm::allocate(blocks, memory.data(), 1u)) == memory.data();
+        check(blocks) == 1u;
+
+        check(bm::allocate(blocks, memory.data(), 1u)) == memory.data() + 1;
+        check(blocks) == 3u;
+
+        bm::free(memory.data(), blocks, memory.data(), 1u);
+        check(blocks) == 2u;
+
+        bm::free(memory.data() + 1, blocks, memory.data(), 1u);
+        check(blocks) == 0u;
     });
 
 


### PR DESCRIPTION
This is the basic stuff needed for a bitmap allocator. This version will only allow for a number of allocations equal to the number of bits in the numeric type used to control the allocation.