### PR TITLE
Polymorphic memory resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: ninja -C build.tmp/
       - run:
           name: check tests
-          command: ninja -C build.tmp/ check
+          command: ninja -C build.tmp/ felspar-check
 
 workflows:
   all-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,13 @@ executors:
     environment:
       CC: gcc-10
       CXX: g++-10
+  gcc-pmr:
+    docker:
+    - image: fost/circleci
+    environment:
+      CC: gcc-10
+      CXX: g++-10
+      FELSPAR_FORCE_PMR: YES
 
 jobs:
   build:
@@ -60,5 +67,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              compiler: [gcc, clang, clang-libcpp, clang-asan]
+              compiler: [gcc, clang, clang-libcpp, clang-asan, gcc-pmr]
               variant: [Debug, Release]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 project(felspar-memory)
 
+
+set(FELSPAR_FORCE_PMR NO CACHE BOOL
+    "Force use of polyfilled version of std::pmr")
+
+
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     add_custom_target(felspar-check)
     set_property(TARGET felspar-check PROPERTY EXCLUDE_FROM_ALL TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(felspar-memory)
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    add_custom_target(check)
+    add_custom_target(felspar-check)
+    set_property(TARGET felspar-check PROPERTY EXCLUDE_FROM_ALL TRUE)
     include(requirements.cmake)
 endif()
 
@@ -11,7 +12,6 @@ target_include_directories(felspar-memory INTERFACE include)
 target_compile_features(felspar-memory INTERFACE cxx_std_20)
 target_link_libraries(felspar-memory INTERFACE felspar-exceptions)
 
-if(TARGET check)
-    set_property(TARGET check PROPERTY EXCLUDE_FROM_ALL TRUE)
+if(TARGET felspar-check)
     add_subdirectory(test)
 endif()

--- a/config-builds
+++ b/config-builds
@@ -44,3 +44,13 @@ $CMAKE -B build.tmp/clang-debug-asan \
 $CMAKE -B build.tmp/clang-release-asan \
     -DCMAKE_INSTALL_PREFIX=dist/clang-release-asan \
     -DCMAKE_BUILD_TYPE=Release
+
+
+$CMAKE -B build.tmp/clang-debug-pmr-asan \
+    -DCMAKE_INSTALL_PREFIX=dist/clang-debug-asan \
+    -DFELSPAR_FORCE_PMR=YES
+
+$CMAKE -B build.tmp/clang-release-pmr-asan \
+    -DCMAKE_INSTALL_PREFIX=dist/clang-release-asan \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DFELSPAR_FORCE_PMR=YES

--- a/do-build
+++ b/do-build
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+time (
+        # User specified targets
+        ninja -C ./build.tmp/clang-debug $* &&
+        # Debug builds
+        ninja -C ./build.tmp/clang-debug all felspar-check &&
+        ninja -C ./build.tmp/gcc-debug all felspar-check &&
+        # Release builds
+        ninja -C ./build.tmp/clang-release all felspar-check &&
+        ninja -C ./build.tmp/gcc-release all felspar-check &&
+        # stdlib=libc++
+        ninja -C ./build.tmp/clang-debug-libc++ all felspar-check &&
+        ninja -C ./build.tmp/clang-release-libc++ all felspar-check &&
+        # stdlib=libc++ asan
+        ninja -C ./build.tmp/clang-debug-asan all felspar-check &&
+        ninja -C ./build.tmp/clang-release-asan all felspar-check &&
+        # stdlib=libc++ asan force PMR
+        ninja -C ./build.tmp/clang-debug-pmr-asan all felspar-check &&
+        ninja -C ./build.tmp/clang-release-pmr-asan all felspar-check &&
+        true
+    ) && (
+        find ./include/ ./test/ -name \*.\?pp -print | xargs clang-format -i
+    )

--- a/include/felspar/memory/fixed-pool.pmr.hpp
+++ b/include/felspar/memory/fixed-pool.pmr.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+
+#include <felspar/memory/pmr.hpp>
+
+#include <string>
+#include <vector>
+
+
+namespace felspar::memory {
+
+
+    /// A pool of a single fixed size. Any allocation larger than this is given
+    /// to the backing allocator
+    class fixed_pool : public pmr::memory_resource {
+        void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+            if (alignment > alignof(std::max_align_t)) {
+                throw std::logic_error{
+                        "Requested over-aligned memory from the pool of "
+                        + std::to_string(alignment) + " bytes"};
+            } else if (bytes <= max_size and not pool.empty()) {
+                std::byte *const v = pool.back();
+                pool.pop_back();
+                return v;
+            } else {
+                return allocator->allocate(std::max(max_size, bytes));
+            }
+        }
+        void do_deallocate(void *p, std::size_t bytes, std::size_t) override {
+            if (bytes <= max_size) {
+                pool.push_back(reinterpret_cast<std::byte *>(p));
+            } else {
+                allocator->deallocate(p, bytes);
+            }
+        }
+        bool do_is_equal(memory_resource const &other) const noexcept override {
+            return this == &other;
+        }
+
+        std::size_t max_size;
+        pmr::memory_resource *allocator;
+        std::vector<std::byte *> pool;
+
+      public:
+        fixed_pool(
+                std::size_t const max_size,
+                pmr::memory_resource *const allocator)
+        : max_size{max_size}, allocator{allocator} {}
+        ~fixed_pool() {
+            if (allocator) {
+                for (auto v : pool) { allocator->deallocate(v, max_size); }
+            }
+        }
+
+        fixed_pool(fixed_pool const &) = delete;
+        fixed_pool &operator=(fixed_pool const &) = delete;
+    };
+
+
+}

--- a/include/felspar/memory/pmr.hpp
+++ b/include/felspar/memory/pmr.hpp
@@ -8,11 +8,8 @@
 #include <memory_resource>
 
 
-namespace felspar::pmr {
-    using memory_resource = std::pmr::memory_resource;
-    inline auto *new_delete_resource() noexcept {
-        return std::pmr::new_delete_resource();
-    }
+namespace felspar {
+    namespace pmr = std::pmr;
 }
 
 

--- a/include/felspar/memory/pmr.hpp
+++ b/include/felspar/memory/pmr.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+
+#ifndef FELSPAR_FORCE_PMR
+
+#if __has_include(<memory_resource>)
+
+#include <memory_resource>
+
+
+namespace felspar::pmr {
+    using memory_resource = std::pmr::memory_resource;
+}
+
+
+#else
+#define FELSPAR_FORCE_PMR
+#endif
+
+#endif
+
+
+#ifdef FELSPAR_FORCE_PMR
+
+
+#include <cstddef>
+
+
+namespace felspar::pmr {
+
+
+    class memory_resource {
+        virtual void *do_allocate(std::size_t bytes, std::size_t alignment) = 0;
+        virtual void do_deallocate(
+                void *p, std::size_t bytes, std::size_t alignment) = 0;
+        virtual bool
+                do_is_equal(memory_resource const &other) const noexcept = 0;
+
+      public:
+        [[nodiscard]] void *allocate(
+                std::size_t bytes,
+                std::size_t alignment = alignof(std::max_align_t)) {
+            return do_allocate(bytes, alignment);
+        }
+        void deallocate(
+                void *p,
+                std::size_t bytes,
+                std::size_t alignment = alignof(std::max_align_t)) {
+            return do_deallocate(p, bytes, alignment);
+        }
+        [[nodiscard]] bool
+                is_equal(memory_resource const &other) const noexcept {
+            return do_is_equal(other);
+        }
+    };
+
+
+}
+
+
+#endif

--- a/include/felspar/memory/slab.storage.hpp
+++ b/include/felspar/memory/slab.storage.hpp
@@ -42,7 +42,7 @@ namespace felspar::memory {
                 return base;
             }
         }
-        constexpr void deallocate(void *) {}
+        constexpr void deallocate(void *, std::size_t) {}
     };
 
 

--- a/include/felspar/memory/stack.storage.hpp
+++ b/include/felspar/memory/stack.storage.hpp
@@ -98,6 +98,7 @@ namespace felspar::memory {
         }
         constexpr void deallocate(
                 void *location,
+                std::size_t,
                 source_location loc = source_location::current()) {
             for (auto pos = allocations.begin(); pos != allocations.end();
                  ++pos) {

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(memory-headers-tests STATIC EXCLUDE_FROM_ALL
         bitmap.strategy.cpp
         concepts.cpp
         control.cpp
+        fixed-pool.pmr.cpp
         holding_pen.cpp
         pmr.cpp
         raw_memory.cpp

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(memory-headers-tests STATIC EXCLUDE_FROM_ALL
         concepts.cpp
         control.cpp
         holding_pen.cpp
+        pmr.cpp
         raw_memory.cpp
         sizes.cpp
         small_ring.cpp

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -13,4 +13,4 @@ add_library(memory-headers-tests STATIC EXCLUDE_FROM_ALL
         stack.storage.cpp
     )
 target_link_libraries(memory-headers-tests felspar-memory)
-add_dependencies(check memory-headers-tests)
+add_dependencies(felspar-check memory-headers-tests)

--- a/test/headers/fixed-pool.pmr.cpp
+++ b/test/headers/fixed-pool.pmr.cpp
@@ -1,0 +1,1 @@
+#include <felspar/memory/fixed-pool.pmr.hpp>

--- a/test/headers/pmr.cpp
+++ b/test/headers/pmr.cpp
@@ -1,0 +1,3 @@
+#include <felspar/memory/pmr.hpp>
+
+using memory_resource = felspar::pmr::memory_resource;

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -1,5 +1,5 @@
-if(TARGET check)
-    add_test_run(check felspar-memory TESTS
+if(TARGET felspar-check)
+    add_test_run(felspar-check felspar-memory TESTS
             bitmap.cpp
             holding_pen.cpp
             raw_memory.cpp

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -2,6 +2,7 @@ if(TARGET felspar-check)
     add_test_run(felspar-check felspar-memory TESTS
             bitmap.cpp
             holding_pen.cpp
+            pmr.cpp
             raw_memory.cpp
             sizes.cpp
             slab.storage.cpp

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -1,6 +1,7 @@
 if(TARGET felspar-check)
     add_test_run(felspar-check felspar-memory TESTS
             bitmap.cpp
+            fixed-pool.pmr.cpp
             holding_pen.cpp
             pmr.cpp
             raw_memory.cpp

--- a/test/run/fixed-pool.pmr.cpp
+++ b/test/run/fixed-pool.pmr.cpp
@@ -1,0 +1,43 @@
+#include <felspar/memory/fixed-pool.pmr.hpp>
+#include <felspar/test.hpp>
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("fixed-pool.pmr");
+
+
+    auto const s = suite.test("small", [](auto check) {
+        felspar::memory::fixed_pool fp{
+                512, felspar::pmr::new_delete_resource()};
+
+        void *a1 = fp.allocate(100);
+        void *a2 = fp.allocate(100);
+        check(a1) != a2;
+        fp.deallocate(a1, 100);
+        fp.deallocate(a2, 100);
+
+        void *a3 = fp.allocate(200);
+        check(a3) == a2;
+        fp.deallocate(a3, 200);
+    });
+
+
+    auto const b = suite.test("big", [](auto check) {
+        felspar::memory::fixed_pool fp{
+                512, felspar::pmr::new_delete_resource()};
+
+        void *a1 = fp.allocate(1000);
+        void *a2 = fp.allocate(1000);
+        check(a1) != a2;
+        fp.deallocate(a1, 1000);
+        fp.deallocate(a2, 1000);
+
+        void *a3 = fp.allocate(2000);
+        check(a3) != a2;
+        fp.deallocate(a3, 2000);
+    });
+
+
+}

--- a/test/run/pmr.cpp
+++ b/test/run/pmr.cpp
@@ -1,0 +1,18 @@
+#include <felspar/memory/pmr.hpp>
+#include <felspar/test.hpp>
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("pmr");
+
+
+    auto const eq = suite.test("is_equal", [](auto check) {
+        check(felspar::pmr::new_delete_resource()->is_equal(
+                *felspar::pmr::new_delete_resource()))
+                == true;
+    });
+
+
+}

--- a/test/run/slab.storage.cpp
+++ b/test/run/slab.storage.cpp
@@ -21,8 +21,8 @@ namespace {
         check(a2) == reinterpret_cast<std::byte const *>(&slab) + 8u;
         check(slab.free()) == size - 16u;
 
-        slab.deallocate(a1);
-        slab.deallocate(a2);
+        slab.deallocate(a1, 8u);
+        slab.deallocate(a2, 1u);
         check(slab.free()) == (1u << 10) - 16u;
     });
 

--- a/test/run/stack.storage.cpp
+++ b/test/run/stack.storage.cpp
@@ -54,22 +54,22 @@ namespace {
         auto a3 = stack.allocate(1u);
         check(a3) == reinterpret_cast<std::byte const *>(&stack) + 16u;
 
-        stack.deallocate(a3);
+        stack.deallocate(a3, 1u);
         auto a4 = stack.allocate(1u);
         check(a4) == a3;
 
-        stack.deallocate(a1);
+        stack.deallocate(a1, 1u);
         auto a5 = stack.allocate(1u);
         check(a5) == reinterpret_cast<std::byte const *>(&stack);
-        stack.deallocate(a5);
+        stack.deallocate(a5, 1u);
 
-        stack.deallocate(a2);
-        stack.deallocate(a4);
+        stack.deallocate(a2, 1u);
+        stack.deallocate(a4, 1u);
         check(stack.free()) == 64u;
 
         auto a6 = stack.allocate(1u);
         check(a6) == reinterpret_cast<std::byte const *>(&stack);
-        stack.deallocate(a6);
+        stack.deallocate(a6, 1u);
         check(stack.free()) == 64u;
     });
 


### PR DESCRIPTION
Adds a basic polly fill for parts of `std::pmr` that may not be available on all compilers/libraries.